### PR TITLE
Add match_word argument for git_blacklist

### DIFF
--- a/config/magento2/grumphp.yml
+++ b/config/magento2/grumphp.yml
@@ -17,4 +17,5 @@ parameters:
     - "====="
     - "<?php echo"
     - "Magento\\\\Framework\\\\App\\\\ObjectManager"
+  git_blacklist.match_word: true
   git_blacklist.triggered_by: [ 'php', 'js', 'phtml' ]


### PR DESCRIPTION
To avoid triggering on add() while dd() is blacklisted. See https://github.com/phpro/grumphp/issues/803