### PR TITLE
Set match_word to true for git_blacklist

### DIFF
--- a/config/default/grumphp.yml
+++ b/config/default/grumphp.yml
@@ -51,6 +51,7 @@ parameters:
     - "alert("
     - "print_r("
     - "phpinfo("
+    - "exit("
     - "exit;"
     - "<<<<<"
     - ">>>>>"
@@ -59,7 +60,7 @@ parameters:
   git_blacklist.triggered_by: [ 'php', 'js' ]
   git_blacklist.whitelist_patterns: []
   git_blacklist.regexp_type: G
-  git_blacklist.match_word: false
+  git_blacklist.match_word: true
 
 grumphp:
   ascii:


### PR DESCRIPTION
To avoid triggering on add() while dd() is blacklisted. Also added [`exit(`](https://www.php.net/exit)

See;
- https://github.com/YouweGit/testing-suite/pull/14
- https://github.com/phpro/grumphp/issues/803
- https://github.com/phpro/grumphp/pull/804

> This option allows you to choose how the keywords is found.
> 
> For instance let's say you have a keyword looking like `"dd("` by default this task would also find any
> text before or after the keyword meaning this: `function add($someTask)` would still be considered invalid.
> This configuration option allows you to get around that issue.