### PR TITLE
fix: resolve blacklist false-positives for specific function names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.16.1
+### Changed
+- Git blacklist now matches on words instead of characters by default.
+- The git blacklist configuration for rejecting accidentally commited merge conflicts now properly reflects the
+full set of characters used by git.
+
+### Fixed
+- Resolved issue where the updated git blacklist configuration would provide a false positive result
+on functions ending with `add()` or `odd()` due to checks on dump and die `dd()` statements.
+
+### Added
+- Git blacklist now checks for `exit()` usage.
+
 ## 2.16.0
 ### Fixed
 - Testing suite no longer breaks during installation when composer project type is set to `pimcore-project`.

--- a/config/default/grumphp.yml
+++ b/config/default/grumphp.yml
@@ -51,15 +51,16 @@ parameters:
     - "alert("
     - "print_r("
     - "phpinfo("
+    - "exit("
     - "exit;"
-    - "<<<<<"
-    - ">>>>>"
-    - "====="
+    - "<<<<<<<"
+    - ">>>>>>>"
+    - "======="
     - "<?php echo"
   git_blacklist.triggered_by: [ 'php', 'js' ]
   git_blacklist.whitelist_patterns: []
   git_blacklist.regexp_type: G
-  git_blacklist.match_word: false
+  git_blacklist.match_word: true
 
 grumphp:
   ascii:


### PR DESCRIPTION
### Changed
- Git blacklist now matches on words instead of characters by default.
- The git blacklist configuration for rejecting accidentally commited merge conflicts now properly reflects the
full set of characters used by git.

### Fixed
- Resolved issue where the updated git blacklist configuration would provide a false positive result
on functions ending with `add()` or `odd()` due to checks on dump and die `dd()` statements.

### Added
- Git blacklist now checks for `exit()` usage.