### PR TITLE
Update enlightn/security-checker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "composer-plugin-api": "^1.1 || ^2.0",
-        "enlightn/security-checker": "^1.5",
+        "enlightn/security-checker": "^2.0",
         "kint-php/kint": "@stable",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "phpro/grumphp-shim": "^1.13",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "composer-plugin-api": "^1.1 || ^2.0",
-        "enlightn/security-checker": "^2.0",
+        "enlightn/security-checker": "^1.5 || ^2.0",
         "kint-php/kint": "@stable",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "phpro/grumphp-shim": "^1.13",


### PR DESCRIPTION
Version 2.0 is required for the latest laravel version due to an symphony update.

https://github.com/enlightn/security-checker/issues/33