### PR TITLE
Task `Security Enlightn` will now only tell what composer packages ha…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.19.2
+### Fixed
+- Task `Security Enlightn` will now only tell what composer packages have security issues, but will not block
+  the passing of the testing suite.
+
 ## 2.19.1
 ### Changed
 - `^0.30` restricts updates to only versions within the `0.30.x` range, preventing upgrades to 0.32.0 for

--- a/config/default/grumphp.yml
+++ b/config/default/grumphp.yml
@@ -132,3 +132,5 @@ grumphp:
     securitychecker_enlightn:
       lockfile: '%securitychecker.lockfile%'
       run_always: '%securitychecker.run_always%'
+      metadata:
+        blocking: false


### PR DESCRIPTION
…ve security issues, but will not block

  the passing of the testing suite.