### PR TITLE
feat: bump packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.0] - Unreleased
+## [3.0.0]
 ### Added
 - Added `phpunit/phpunit` to suggested dependencies in `composer.json`.
 - Added `youwe/coding-standard-phpstorm` to suggested dependencies in `composer.json`.
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved existing project-type specific rulesets from inner dependencies to testing-suite package.
 - Simplified PHPMD rulesets with rationale behind rule changes.
 - Updated remote schema location URL for phpmd rulesets to prevent redirecting which may cause flaky builds.
+- Bumped phpro/grumphp-shim dependency from v1 to v2
 
 ### Removed
 - Removed support for EOL PHP versions. Projects running PHP < 8.1 can stick to version 2 of the testing-suite.

--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,12 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "enlightn/security-checker": "^1.5 || ^2.0",
         "kint-php/kint": "@stable",
-        "php-parallel-lint/php-parallel-lint": "^1.2",
+        "php-parallel-lint/php-parallel-lint": "^1.4",
         "phpmd/phpmd": "^2.15",
-        "phpro/grumphp-shim": "^1.13",
+        "phpro/grumphp-shim": "^2.12",
         "phpstan/phpstan": "@stable",
         "squizlabs/php_codesniffer": "^3.12.0",
-        "youwe/composer-dependency-installer": "^1.4.0",
+        "youwe/composer-dependency-installer": "^1.5.0",
         "youwe/composer-file-installer": "^1.2.0"
     },
     "suggest": {


### PR DESCRIPTION
* Drop support for englightn/security-checker v1
* Bump grumphp-shim to v2
* Minor json version correction to match currently installed versions during builds