### PR TITLE
Add PHP 8.4 compatibility

### DIFF
--- a/src/ConfigResolver.php
+++ b/src/ConfigResolver.php
@@ -11,30 +11,21 @@ namespace Youwe\TestingSuite\Composer;
 
 class ConfigResolver
 {
-    /** @var ProjectTypeResolver */
-    private $typeResolver;
-
     /** @var string */
     private $template = __DIR__ . '/../templates/config/%s.json';
 
     /**
      * Constructor.
-     *
-     * @param ProjectTypeResolver $typeResolver
-     * @param string              $template
      */
     public function __construct(
-        ProjectTypeResolver $typeResolver,
-        string $template = null
+        private readonly ProjectTypeResolver $typeResolver,
+        ?string $template = null
     ) {
-        $this->typeResolver = $typeResolver;
         $this->template     = $template ?? $this->template;
     }
 
     /**
      * Resolve config.
-     *
-     * @return array
      */
     public function resolve(): array
     {

--- a/src/Factory/ProcessFactory.php
+++ b/src/Factory/ProcessFactory.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Youwe\TestingSuite\Composer\Factory;
 
+use Override;
 use Symfony\Component\Process\Process;
 
 class ProcessFactory implements ProcessFactoryInterface
@@ -16,10 +17,9 @@ class ProcessFactory implements ProcessFactoryInterface
     /**
      * Create a new Process instance.
      *
-     * @param string $commandLine
      *
-     * @return Process
      */
+    #[Override]
     public function create(string $commandLine): Process
     {
         // See https://github.com/composer/composer/blob/1.10.17/src/Composer/Util/ProcessExecutor.php#L68:L72

--- a/src/Factory/ProcessFactoryInterface.php
+++ b/src/Factory/ProcessFactoryInterface.php
@@ -16,9 +16,7 @@ interface ProcessFactoryInterface
     /**
      * Create a new Process instance.
      *
-     * @param string $commandLine
      *
-     * @return Process
      */
     public function create(string $commandLine): Process;
 }

--- a/src/Installer/ConfigInstaller.php
+++ b/src/Installer/ConfigInstaller.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Youwe\TestingSuite\Composer\Installer;
 
+use Override;
 use Composer\Factory;
 use Composer\IO\IOInterface;
 use Composer\Json\JsonFile;
@@ -20,31 +21,24 @@ use Youwe\TestingSuite\Composer\ConfigResolver;
  */
 class ConfigInstaller implements InstallerInterface
 {
-    /** @var JsonFile */
-    private $file;
-
-    /** @var ConfigResolver */
-    private $resolver;
+    private readonly JsonFile $file;
 
     /**
      * Constructor.
      *
-     * @param ConfigResolver $resolver
      * @param JsonFile|null  $file
      */
     public function __construct(
-        ConfigResolver $resolver,
-        JsonFile $file = null
+        private readonly ConfigResolver $resolver,
+        ?JsonFile $file = null
     ) {
-        $this->resolver = $resolver;
         $this->file     = $file ?? new JsonFile(Factory::getComposerFile());
     }
 
     /**
      * Install.
-     *
-     * @return void
      */
+    #[Override]
     public function install(): void
     {
         $definition = $this->file->read();

--- a/src/Installer/FilesInstaller.php
+++ b/src/Installer/FilesInstaller.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Youwe\TestingSuite\Composer\Installer;
 
+use Override;
 use Composer\IO\IOInterface;
 use Youwe\Composer\FileInstaller as ComposerFileInstaller;
 use Youwe\FileMapping\FileMappingInterface;
@@ -19,37 +20,17 @@ use Youwe\TestingSuite\Composer\MappingResolver;
  */
 class FilesInstaller implements InstallerInterface
 {
-    /** @var MappingResolver */
-    private $mappingResolver;
-
-    /** @var ComposerFileInstaller */
-    private $fileInstaller;
-
-    /** @var IOInterface */
-    private $io;
-
     /**
      * Constructor.
-     *
-     * @param MappingResolver       $mappingResolver
-     * @param ComposerFileInstaller $fileInstaller
-     * @param IOInterface           $io
      */
-    public function __construct(
-        MappingResolver $mappingResolver,
-        ComposerFileInstaller $fileInstaller,
-        IOInterface $io
-    ) {
-        $this->mappingResolver = $mappingResolver;
-        $this->fileInstaller   = $fileInstaller;
-        $this->io              = $io;
+    public function __construct(private readonly MappingResolver $mappingResolver, private readonly ComposerFileInstaller $fileInstaller, private readonly IOInterface $io)
+    {
     }
 
     /**
      * Install.
-     *
-     * @return void
      */
+    #[Override]
     public function install(): void
     {
         foreach ($this->mappingResolver->resolve() as $mapping) {
@@ -70,11 +51,9 @@ class FilesInstaller implements InstallerInterface
     }
 
     /**
-     * @param FileMappingInterface $unixFileMapping
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      *
-     * @return void
      */
     private function resolveYouwePathing(FileMappingInterface $unixFileMapping): void
     {
@@ -119,39 +98,31 @@ class FilesInstaller implements InstallerInterface
                     './vendor/youwe/coding-standard-magento1/src/Magento1'
                 );
             }
-        } else {
-            if ($name === "phpcs.xml") {
-                $this->updatePath(
-                    $unixFileMapping->getDestination(),
-                    ['./vendor/mediact/coding-standard/src/MediaCT'],
-                    './vendor/youwe/coding-standard/src/Global'
-                );
-            } elseif ($name === "phpmd.xml") {
-                $this->updatePath(
-                    $unixFileMapping->getDestination(),
-                    [
-                        './vendor/mediact/coding-standard/src/MediaCT/phpmd.xml',
-                        './vendor/youwe/coding-standard-magento2/src/Magento2/phpmd.xml'
-                    ],
-                    './vendor/youwe/coding-standard/src/Global/phpmd.xml'
-                );
-            } elseif ($name === "grumphp.yml") {
-                $this->updatePath(
-                    $unixFileMapping->getDestination(),
-                    ['vendor/mediact/testing-suite/config/default/grumphp.yml'],
-                    'vendor/youwe/testing-suite/config/default/grumphp.yml'
-                );
-            }
+        } elseif ($name === "phpcs.xml") {
+            $this->updatePath(
+                $unixFileMapping->getDestination(),
+                ['./vendor/mediact/coding-standard/src/MediaCT'],
+                './vendor/youwe/coding-standard/src/Global'
+            );
+        } elseif ($name === "phpmd.xml") {
+            $this->updatePath(
+                $unixFileMapping->getDestination(),
+                [
+                    './vendor/mediact/coding-standard/src/MediaCT/phpmd.xml',
+                    './vendor/youwe/coding-standard-magento2/src/Magento2/phpmd.xml'
+                ],
+                './vendor/youwe/coding-standard/src/Global/phpmd.xml'
+            );
+        } elseif ($name === "grumphp.yml") {
+            $this->updatePath(
+                $unixFileMapping->getDestination(),
+                ['vendor/mediact/testing-suite/config/default/grumphp.yml'],
+                'vendor/youwe/testing-suite/config/default/grumphp.yml'
+            );
         }
     }
 
-    /**
-     * @param string $destination
-     * @param array  $oldPaths
-     * @param string $newPath
-     *
-     * @return void
-     */
+    
     private function updatePath(
         string $destination,
         array $oldPaths,

--- a/src/Installer/InstallerInterface.php
+++ b/src/Installer/InstallerInterface.php
@@ -13,8 +13,6 @@ interface InstallerInterface
 {
     /**
      * Install.
-     *
-     * @return void
      */
     public function install(): void;
 }

--- a/src/Installer/PackagesInstaller.php
+++ b/src/Installer/PackagesInstaller.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Youwe\TestingSuite\Composer\Installer;
 
+use Override;
 use Composer\Composer;
 use Composer\IO\IOInterface;
 use Youwe\Composer\DependencyInstaller\DependencyInstaller;
@@ -20,18 +21,6 @@ use Youwe\TestingSuite\Composer\ProjectTypeResolver;
  */
 class PackagesInstaller implements InstallerInterface
 {
-    /** @var DependencyInstaller */
-    private $installer;
-
-    /** @var Composer */
-    private $composer;
-
-    /** @var ProjectTypeResolver */
-    private $typeResolver;
-
-    /** @var IOInterface */
-    private $io;
-
     /** @var array */
     private $mapping = [
         MappingResolver::DEFAULT_MAPPING_TYPE => [],
@@ -71,31 +60,23 @@ class PackagesInstaller implements InstallerInterface
     /**
      * Constructor.
      *
-     * @param Composer                 $composer
-     * @param ProjectTypeResolver      $typeResolver
-     * @param IOInterface              $io
      * @param DependencyInstaller|null $installer
      * @param array|null               $mapping
      */
     public function __construct(
-        Composer $composer,
-        ProjectTypeResolver $typeResolver,
-        IOInterface $io,
-        DependencyInstaller $installer = null,
-        array $mapping = null
+        private readonly Composer $composer,
+        private readonly ProjectTypeResolver $typeResolver,
+        private readonly IOInterface $io,
+        private readonly DependencyInstaller $installer = new DependencyInstaller(),
+        ?array $mapping = null
     ) {
-        $this->composer     = $composer;
-        $this->typeResolver = $typeResolver;
-        $this->io           = $io;
-        $this->installer    = $installer ?? new DependencyInstaller();
         $this->mapping      = $mapping ?? $this->mapping;
     }
 
     /**
      * Install.
-     *
-     * @return void
      */
+    #[Override]
     public function install(): void
     {
         $type = $this->typeResolver->resolve();
@@ -120,9 +101,7 @@ class PackagesInstaller implements InstallerInterface
     /**
      * Whether a package has been required.
      *
-     * @param string $packageName
      *
-     * @return bool
      */
     private function isPackageRequired(string $packageName, string $version): bool
     {

--- a/src/MappingResolver.php
+++ b/src/MappingResolver.php
@@ -14,25 +14,17 @@ use Youwe\FileMapping\UnixFileMappingReader;
 
 class MappingResolver
 {
-    /** @var ProjectTypeResolver */
-    private $typeResolver;
-
     public const DEFAULT_MAPPING_TYPE = 'default';
 
     /**
      * Constructor.
-     *
-     * @param ProjectTypeResolver $typeResolver
      */
-    public function __construct(ProjectTypeResolver $typeResolver)
+    public function __construct(private readonly ProjectTypeResolver $typeResolver)
     {
-        $this->typeResolver = $typeResolver;
     }
 
     /**
      * Resolve mapping files.
-     *
-     * @return FileMappingReaderInterface
      */
     public function resolve(): FileMappingReaderInterface
     {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Youwe\TestingSuite\Composer;
 
+use Override;
 use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
@@ -21,7 +22,7 @@ use Youwe\TestingSuite\Composer\Installer\InstallerInterface;
 class Plugin implements PluginInterface, EventSubscriberInterface
 {
     /** @var InstallerInterface[] */
-    private $installers;
+    private array $installers;
 
     /**
      * Constructor.
@@ -36,12 +37,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     /**
      * Apply plugin modifications to Composer.
      *
-     * @param Composer    $composer
-     * @param IOInterface $io
      *
-     * @return void
      */
-    public function activate(Composer $composer, IOInterface $io)
+    #[Override]
+    public function activate(Composer $composer, IOInterface $io): void
     {
         $this->addInstallers(
             ...include __DIR__ . '/installers.php'
@@ -51,11 +50,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     /**
      * Remove any hooks from Composer.
      *
-     * @param Composer    $composer
-     * @param IOInterface $io
      *
      * @return void
      */
+    #[Override]
     public function deactivate(Composer $composer, IOInterface $io)
     {
     }
@@ -63,11 +61,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     /**
      * Prepare the plugin to be uninstalled
      *
-     * @param Composer    $composer
-     * @param IOInterface $io
      *
      * @return void
      */
+    #[Override]
     public function uninstall(Composer $composer, IOInterface $io)
     {
     }
@@ -76,20 +73,16 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      * Add installers.
      *
      * @param InstallerInterface[] ...$installers
-     *
-     * @return void
      */
-    public function addInstallers(InstallerInterface ...$installers)
+    public function addInstallers(InstallerInterface ...$installers): void
     {
         $this->installers = array_merge($this->installers, $installers);
     }
 
     /**
      * Run the installers.
-     *
-     * @return void
      */
-    public function install()
+    public function install(): void
     {
         foreach ($this->installers as $installer) {
             $installer->install();
@@ -98,9 +91,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
     /**
      * Subscribe to post update and post install command.
-     *
-     * @return array
      */
+    #[Override]
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/ProjectTypeResolver.php
+++ b/src/ProjectTypeResolver.php
@@ -29,9 +29,6 @@ class ProjectTypeResolver
      */
     public const COMPOSER_CONFIG_TYPE_KEY = 'type';
 
-    /** @var Composer */
-    private $composer;
-
     /** @var array */
     private $mapping = [
         'magento2-module' => 'magento2',
@@ -48,19 +45,15 @@ class ProjectTypeResolver
     /**
      * Constructor.
      *
-     * @param Composer   $composer
      * @param array|null $mapping
      */
-    public function __construct(Composer $composer, array $mapping = null)
+    public function __construct(private readonly Composer $composer, ?array $mapping = null)
     {
-        $this->composer = $composer;
         $this->mapping  = $mapping ?? $this->mapping;
     }
 
     /**
      * Get the type.
-     *
-     * @return string
      */
     public function resolve(): string
     {

--- a/src/installers.php
+++ b/src/installers.php
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 
+use Composer\IO\IOInterface;
 use Youwe\Composer\FileInstaller;
 use Youwe\FileMapping\UnixFileMappingReader;
 use Youwe\TestingSuite\Composer\ConfigResolver;
@@ -20,9 +21,8 @@ use Youwe\TestingSuite\Composer\ProjectTypeResolver;
 
 /**
  * @var Composer\Composer       $composer
- * @var Composer\IO\IOInterface $io
+ * @var IOInterface $io
  */
-
 $typeResolver    = new ProjectTypeResolver($composer);
 $mappingResolver = new MappingResolver($typeResolver);
 $configResolver  = new ConfigResolver($typeResolver);

--- a/tests/ConfigResolverTest.php
+++ b/tests/ConfigResolverTest.php
@@ -21,7 +21,6 @@ use Youwe\TestingSuite\Composer\ProjectTypeResolver;
 class ConfigResolverTest extends TestCase
 {
     /**
-     * @return void
      *
      * @covers ::__construct
      * @covers ::resolve

--- a/tests/Factory/ProcessFactoryTest.php
+++ b/tests/Factory/ProcessFactoryTest.php
@@ -19,11 +19,9 @@ use Youwe\TestingSuite\Composer\Factory\ProcessFactory;
 class ProcessFactoryTest extends TestCase
 {
     /**
-     * @return void
-     *
      * @covers ::create
      */
-    public function testCreate()
+    public function testCreate(): void
     {
         $factory = new ProcessFactory();
 

--- a/tests/Installer/ArchiveExcludeInstallerTest.php
+++ b/tests/Installer/ArchiveExcludeInstallerTest.php
@@ -27,13 +27,6 @@ use Youwe\TestingSuite\Composer\MappingResolver;
 class ArchiveExcludeInstallerTest extends TestCase
 {
     /**
-     * @param array $existingFiles
-     * @param array $files
-     * @param array $defaults
-     * @param array $definition
-     * @param array $expected
-     *
-     * @return void
      *
      * @dataProvider dataProvider
      *
@@ -46,7 +39,7 @@ class ArchiveExcludeInstallerTest extends TestCase
         array $defaults,
         array $definition,
         array $expected
-    ) {
+    ): void {
         $file       = $this->createMock(JsonFile::class);
         $resolver   = $this->createMock(MappingResolver::class);
         $io         = $this->createMock(IOInterface::class);
@@ -79,9 +72,6 @@ class ArchiveExcludeInstallerTest extends TestCase
         $installer->install();
     }
 
-    /**
-     * @return array
-     */
     public function dataProvider(): array
     {
         return [
@@ -121,11 +111,7 @@ class ArchiveExcludeInstallerTest extends TestCase
         ];
     }
 
-    /**
-     * @param array $files
-     *
-     * @return FileMappingReaderInterface
-     */
+    
     private function createReaderMock(array $files): FileMappingReaderInterface
     {
         /** @var FileMappingReaderInterface|MockObject $mock */
@@ -166,11 +152,7 @@ class ArchiveExcludeInstallerTest extends TestCase
         return $mock;
     }
 
-    /**
-     * @param array $files
-     *
-     * @return vfsStreamDirectory
-     */
+    
     private function createFilesystem(array $files): vfsStreamDirectory
     {
         return vfsStream::setup(

--- a/tests/Installer/ConfigInstallerTest.php
+++ b/tests/Installer/ConfigInstallerTest.php
@@ -22,7 +22,6 @@ use Youwe\TestingSuite\Composer\Installer\ConfigInstaller;
 class ConfigInstallerTest extends TestCase
 {
     /**
-     * @return void
      *
      * @covers ::__construct
      * @covers ::install
@@ -60,9 +59,6 @@ class ConfigInstallerTest extends TestCase
         $installer->install();
     }
 
-    /**
-     * @return array
-     */
     public function dataProvider(): array
     {
         return [

--- a/tests/Installer/FilesInstallerTest.php
+++ b/tests/Installer/FilesInstallerTest.php
@@ -27,11 +27,7 @@ use Youwe\TestingSuite\Composer\MappingResolver;
 class FilesInstallerTest extends TestCase
 {
     /**
-     * @param array $existingFiles
-     * @param array $files
-     * @param int   $expectedInstalls
      *
-     * @return void
      * @dataProvider dataProvider
      *
      * @covers ::__construct
@@ -41,7 +37,7 @@ class FilesInstallerTest extends TestCase
         array $existingFiles,
         array $files,
         int $expectedInstalls
-    ) {
+    ): void {
         $filesystem    = $this->createFilesystem($existingFiles);
         $reader        = $this->createReaderMock($files, $filesystem->url());
         $resolver      = $this->createMock(MappingResolver::class);
@@ -61,9 +57,6 @@ class FilesInstallerTest extends TestCase
         $installer->install();
     }
 
-    /**
-     * @return array
-     */
     public function dataProvider(): array
     {
         return [
@@ -81,12 +74,7 @@ class FilesInstallerTest extends TestCase
         ];
     }
 
-    /**
-     * @param array  $files
-     * @param string $destination
-     *
-     * @return FileMappingReaderInterface
-     */
+    
     private function createReaderMock(array $files, string $destination): FileMappingReaderInterface
     {
         /** @var FileMappingReaderInterface|MockObject $mock */
@@ -127,11 +115,7 @@ class FilesInstallerTest extends TestCase
         return $mock;
     }
 
-    /**
-     * @param array $files
-     *
-     * @return vfsStreamDirectory
-     */
+    
     private function createFilesystem(array $files): vfsStreamDirectory
     {
         return vfsStream::setup(

--- a/tests/Installer/PackagesInstallerTest.php
+++ b/tests/Installer/PackagesInstallerTest.php
@@ -25,11 +25,7 @@ use Youwe\TestingSuite\Composer\ProjectTypeResolver;
 class PackagesInstallerTest extends TestCase
 {
     /**
-     * @param string     $type
-     * @param array      $requires
-     * @param array|null $expected
      *
-     * @return void
      * @dataProvider dataProvider
      *
      * @covers ::__construct
@@ -39,8 +35,8 @@ class PackagesInstallerTest extends TestCase
     public function testInstall(
         string $type,
         array $requires,
-        array $expected = null
-    ) {
+        ?array $expected = null
+    ): void {
         $composer     = $this->createMock(Composer::class);
         $typeResolver = $this->createMock(ProjectTypeResolver::class);
         $depInstaller = $this->createMock(DependencyInstaller::class);
@@ -72,9 +68,6 @@ class PackagesInstallerTest extends TestCase
         $installer->install();
     }
 
-    /**
-     * @return array
-     */
     public function dataProvider(): array
     {
         return [

--- a/tests/MappingResolverTest.php
+++ b/tests/MappingResolverTest.php
@@ -20,12 +20,11 @@ use Youwe\TestingSuite\Composer\ProjectTypeResolver;
 class MappingResolverTest extends TestCase
 {
     /**
-     * @return void
      *
      * @covers ::__construct
      * @covers ::resolve
      */
-    public function testResolve()
+    public function testResolve(): void
     {
         $typeResolver = $this->createMock(ProjectTypeResolver::class);
         $typeResolver

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -23,12 +23,11 @@ use Youwe\TestingSuite\Composer\Plugin;
 class PluginTest extends TestCase
 {
     /**
-     * @return void
      *
      * @covers ::activate
      * @covers ::addInstallers
      */
-    public function testActivate()
+    public function testActivate(): void
     {
         $plugin = new Plugin();
         $plugin->activate(
@@ -46,12 +45,11 @@ class PluginTest extends TestCase
     }
 
     /**
-     * @return void
      *
      * @covers ::__construct
      * @covers ::install
      */
-    public function testInstall()
+    public function testInstall(): void
     {
         $installers = [
             $this->createMock(InstallerInterface::class),
@@ -69,15 +67,13 @@ class PluginTest extends TestCase
     }
 
     /**
-     * @return void
-     *
      * @covers ::getSubscribedEvents
      */
-    public function testGetSubscribesEvents()
+    public function testGetSubscribesEvents(): void
     {
         $plugin = new Plugin();
 
-        foreach (Plugin::getSubscribedEvents() as $event => $methods) {
+        foreach (Plugin::getSubscribedEvents() as $methods) {
             foreach ($methods as $method) {
                 $this->assertTrue(method_exists($plugin, $method));
             }

--- a/tests/ProjectTypeResolverTest.php
+++ b/tests/ProjectTypeResolverTest.php
@@ -21,10 +21,7 @@ use Youwe\TestingSuite\Composer\ProjectTypeResolver;
 class ProjectTypeResolverTest extends TestCase
 {
     /**
-     * @param string $packageType
-     * @param string $expected
      *
-     * @return void
      *
      * @dataProvider dataProvider
      *
@@ -57,7 +54,6 @@ class ProjectTypeResolverTest extends TestCase
     }
 
     /**
-     * @return void
      *
      * @covers ::__construct
      * @covers ::resolve
@@ -92,9 +88,6 @@ class ProjectTypeResolverTest extends TestCase
         $this->assertEquals('magento2', $decider->resolve());
     }
 
-    /**
-     * @return array
-     */
     public function dataProvider(): array
     {
         return [


### PR DESCRIPTION
Ran Rector with the following config:

```
<?php

declare(strict_types=1);

use Rector\Config\RectorConfig;
use Rector\ValueObject\PhpVersion;
use Rector\Set\ValueObject\LevelSetList;
use Rector\Set\ValueObject\SetList;

return static function (RectorConfig $rectorConfig): void {
    // Set the PHP version to 8.4
    $rectorConfig->phpVersion(PhpVersion::PHP_84);

    // Paths to include for the refactoring
    $rectorConfig->paths([
        __DIR__ . '/src',
        __DIR__ . '/app',
        __DIR__ . '/tests',
    ]);

    // Include rule sets for PHP 8.4
    $rectorConfig->sets([
        LevelSetList::UP_TO_PHP_84,
        SetList::CODE_QUALITY,
        SetList::TYPE_DECLARATION,
        SetList::DEAD_CODE,
    ]);

    // Optionally, add custom configuration for specific Rectors
    $rectorConfig->importNames();
    $rectorConfig->importShortClasses();
};
```