### PR TITLE
fix: don't exclude full */var/* folder in Pimcore PHPCS configuration

### DIFF
--- a/config/pimcore/ruleset.xml
+++ b/config/pimcore/ruleset.xml
@@ -9,5 +9,4 @@
     <exclude-pattern>*/bin/*</exclude-pattern>
     <exclude-pattern>*/install-profiles/*</exclude-pattern>
     <exclude-pattern>*/public/*</exclude-pattern>
-    <exclude-pattern>*/var/*</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
Error: PHPCS didn't scan anything when using in DDEV container
Discovered in version: 3.0.0-rc1
Caused by: exclude on */var/* which matches the /var/www/html root
Resolved with: removing this generic exclude, relying on the more specific excludes that are configured in /templates/files/pimcore/phpcs.xml