### PR TITLE
fix: file installer should prioritize project specific files

### DIFF
--- a/src/MappingResolver.php
+++ b/src/MappingResolver.php
@@ -37,11 +37,11 @@ class MappingResolver
     public function resolve(): FileMappingReaderInterface
     {
         $files = [
-            __DIR__ . '/../templates/mapping/files',
             sprintf(
                 __DIR__ . '/../templates/mapping/project/%s',
                 $this->typeResolver->resolve(),
             ),
+            __DIR__ . '/../templates/mapping/files',
         ];
 
         return new UnixFileMappingReader(


### PR DESCRIPTION
Discovered in: version 3.0.0-rc1
Error: within a Pimcore project, the `templates/files/default/grumphp.yml` instead of `templates/files/pimcore/grumphp.yml`
Caused by: the default file mapping was executed first, installing the `grumphp.yml` and the project-specific file mapping was executed second, ignoring the (by then) already existing `grumphp.yml`
Resolved with: installing the project specific files first