### PR TITLE
feat: only run the Testing Suite installer on actual composer require/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated remote schema location URL for phpmd rulesets to prevent redirecting which may cause flaky builds.
 - Bumped phpro/grumphp-shim dependency from v1 to v2
 - Bumped youwe/composer-dependency-installer from v1 to v2
+- Testing Suite files are only installed in the project on actual `composer require youwe/testing-suite` or on 
+  `composer update [youwe/testing-suite]` and no longer on each `composer install`
 
 ### Removed
 - Removed support for EOL PHP versions. Projects running PHP < 8.1 can stick to version 2 of the testing-suite.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -10,9 +10,12 @@ declare(strict_types=1);
 namespace Youwe\TestingSuite\Composer;
 
 use Composer\Composer;
+use Composer\DependencyResolver\Operation;
 use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\Installer\PackageEvent;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
+use UnexpectedValueException;
 use Youwe\TestingSuite\Composer\Installer\InstallerInterface;
 
 /**
@@ -21,8 +24,23 @@ use Youwe\TestingSuite\Composer\Installer\InstallerInterface;
  */
 class Plugin implements PluginInterface, EventSubscriberInterface
 {
+    public const PACKAGE_NAME = 'youwe/testing-suite';
+
     /** @var InstallerInterface[] */
-    private $installers;
+    private array $installers;
+
+    /**
+     * Subscribe to post update and post install command.
+     *
+     * @return array
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'post-package-install' => [ 'onPackageChange' ],
+            'post-package-update' => [ 'onPackageChange' ],
+        ];
+    }
 
     /**
      * Constructor.
@@ -42,7 +60,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      *
      * @return void
      */
-    public function activate(Composer $composer, IOInterface $io)
+    public function activate(Composer $composer, IOInterface $io): void
     {
         $this->addInstallers(
             ...include __DIR__ . '/installers.php',
@@ -57,7 +75,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      *
      * @return void
      */
-    public function deactivate(Composer $composer, IOInterface $io)
+    public function deactivate(Composer $composer, IOInterface $io): void
     {
     }
 
@@ -69,7 +87,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      *
      * @return void
      */
-    public function uninstall(Composer $composer, IOInterface $io)
+    public function uninstall(Composer $composer, IOInterface $io): void
     {
     }
 
@@ -80,37 +98,35 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      *
      * @return void
      */
-    public function addInstallers(InstallerInterface ...$installers)
+    public function addInstallers(InstallerInterface ...$installers): void
     {
         $this->installers = array_merge($this->installers, $installers);
     }
 
     /**
-     * Run the installers.
+     * Run the installers when this package has been installed/updated
      *
+     * @param PackageEvent $event
      * @return void
      */
-    public function install()
+    public function onPackageChange(PackageEvent $event): void
     {
+        $operation = $event->getOperation();
+
+        $packageName = match (true) {
+            $operation instanceof Operation\InstallOperation => $operation->getPackage()->getName(),
+            $operation instanceof Operation\UpdateOperation => $operation->getTargetPackage()->getName(),
+            default => throw new UnexpectedValueException('Unexpected operation type: ' . $operation::class),
+        };
+
+        if ($packageName !== self::PACKAGE_NAME) {
+            echo "Skipping Youwe Testing Suite installer\n";
+            return;
+        }
+
+        echo "Running Youwe Testing Suite installer\n";
         foreach ($this->installers as $installer) {
             $installer->install();
         }
-    }
-
-    /**
-     * Subscribe to post update and post install command.
-     *
-     * @return array
-     */
-    public static function getSubscribedEvents(): array
-    {
-        return [
-            'post-install-cmd' => [
-                'install',
-            ],
-            'post-update-cmd' => [
-                'install',
-            ],
-        ];
     }
 }

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -10,8 +10,12 @@ declare(strict_types=1);
 namespace Youwe\TestingSuite\Composer\Tests;
 
 use Composer\Composer;
+use Composer\DependencyResolver\Operation;
+use Composer\Installer\PackageEvent;
 use Composer\IO\IOInterface;
+use Composer\Package\PackageInterface;
 use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
@@ -49,8 +53,28 @@ class PluginTest extends TestCase
     /**
      * @throws Exception
      */
-    public function testInstall(): void
-    {
+    #[TestWith(
+        data: [Operation\InstallOperation::class, 'getPackage', 'youwe/testing-suite', true],
+        name: 'It runs installers when installing Testing Suite',
+    )]
+    #[TestWith(
+        data: [Operation\UpdateOperation::class, 'getTargetPackage', 'youwe/testing-suite', true],
+        name: 'It runs installers when updating Testing Suite',
+    )]
+    #[TestWith(
+        data: [Operation\InstallOperation::class, 'getPackage', 'youwe/coding-standard-phpstorm', false],
+        name: 'It doesn\'t run installers when installing something else',
+    )]
+    #[TestWith(
+        data: [Operation\UpdateOperation::class, 'getTargetPackage', 'youwe/coding-standard-phpstorm', false],
+        name: 'It doesn\'t run installers when updating something else',
+    )]
+    public function testOnPackageChange(
+        string $operationClass,
+        string $packageGetter,
+        string $packageName,
+        bool $itRunsInstallers,
+    ): void {
         $installers = [
             $this->createMock(InstallerInterface::class),
             $this->createMock(InstallerInterface::class)
@@ -58,12 +82,28 @@ class PluginTest extends TestCase
 
         foreach ($installers as $installer) {
             $installer
-                ->expects(self::once())
+                ->expects($itRunsInstallers ? self::once() : self::never())
                 ->method('install');
         }
 
         $plugin = new Plugin(...$installers);
-        $plugin->install();
+
+        $package = $this->createMock(PackageInterface::class);
+        $package->expects(self::once())
+            ->method('getName')
+            ->willReturn($packageName);
+
+        $operation = $this->createMock($operationClass);
+        $operation->expects(self::once())
+            ->method($packageGetter)
+            ->willReturn($package);
+
+        $event = $this->createMock(PackageEvent::class);
+        $event->expects(self::once())
+            ->method('getOperation')
+            ->willReturn($operation);
+
+        $plugin->onPackageChange($event);
     }
 
     public function testGetSubscribesEvents(): void


### PR DESCRIPTION
Only run the installers when actually performing composer operations on this package and no longer on each `composer install`