### PR TITLE
fix: let specify PhpCsFixer config file

### DIFF
--- a/config/default/grumphp.yml
+++ b/config/default/grumphp.yml
@@ -30,6 +30,8 @@ parameters:
 
   phpcsfixer.enabled: false
   phpcsfixer.allow_risky: false
+  phpcsfixer.config: .php-cs-fixer.php # Although we're using the default here, it should be explicitly specified
+                                       # because PhpCsFixer wants the --config=file indicated in the command line call
   phpcsfixer.verbose: true
   phpcsfixer.diff: true
   phpcsfixer.triggered_by: ['php']
@@ -126,6 +128,7 @@ grumphp:
       metadata:
         enabled: '%phpcsfixer.enabled%'
       allow_risky: '%phpcsfixer.allow_risky%'
+      config: '%phpcsfixer.config%'
       verbose: '%phpcsfixer.verbose%'
       diff: '%phpcsfixer.diff%'
       triggered_by: '%phpcsfixer.triggered_by%'


### PR DESCRIPTION
Error: On the commit hook, PhpCsFixer exits with the error "For multiple paths config parameter is required."
Resolved with: Specifying the PhpCsFixer config file in `grumphp.yml` forcing Grumphp to include this argument

Resolves #50

--

### Note:
Skipping the CHANGELOG on purpose. This is a bug that we discovered in the release candidate for 3.0.0 and the [CHANGELOG](https://github.com/YouweGit/testing-suite/blob/master/CHANGELOG.md) already has a `- Option to use PHP CS Fixer instead of PHPCS.` message