### PR TITLE
fix: let PHPStan scan full project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   belongs to configuration from Composer itself. Moving it to the `extra` section which is intended for this purpose 
   (composer docs: "arbitrary extra data for consumption by scripts"). Only the single `extra.youwe-testing-suite.type` 
   is supported now. Update your project `composer.json` accordingly.
+- [BREAKING] PHPStan is now configured to scan the full project, also during commit hooks. This will require to 
+  configure the `paths` setting in your projects `phpstan.neon.`. See the [migration notes](MIGRATION.md) for more
+  precise instructions. This behaviour can be modified with the `phpstan.use_grumphp_paths` parameter in `grumphp.yml`.
+  Please read [Why you should always analyse the whole project](https://phpstan.org/blog/why-you-should-always-analyse-whole-project)
+  before reverting to the old behaviour.
 - Unit tests as part of the testing suite are rewritten for PHPUnit 12.
 - Updated GitHub Action workflows to support PHP 8.1, 8.2, 8.3, and 8.4
 - `composer.json`: Dropped support for PHP < 8.1.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -49,7 +49,38 @@ We use the @stable version constraint for this. If you want to install a specifi
 phpunit version in your project you are free to do so. Upstream phpunit versions
 are honored during installation.
 
-### 3. Sanity checks
+### 3. Change PHPStan configuration
+
+PHPStan is now configured to scan the full project, also during commit hooks. This will require to
+configure the `paths` setting in your projects `phpstan.neon.`.
+
+Example `phpstan.neon` file containing the `paths` parameter:
+```neon
+includes:
+  # To create a baseline run the following command and then uncomment the include below (make sure to run the baseline
+  # command with the same level as configured in Grumphp)
+  #      vendor/bin/phpstan analyse --configuration=./phpstan.neon --generate-baseline --level=4
+  # - phpstan-baseline.neon
+
+parameters:
+  paths:
+    - src
+    
+    # Uncomment when your project has unit tests:
+    # - tests
+
+    # Add any other project folder containing source files, e.g.
+    # - bundles
+
+  excludePaths:
+    # - tests/fixtures/*
+```
+
+As alternative, you can revert your project to the old behaviour by setting the `phpstan.use_grumphp_paths: true` 
+parameter in your `grumphp.yml`. Please read [Why you should always analyse the whole project](https://phpstan.org/blog/why-you-should-always-analyse-whole-project)
+before reverting to the old behaviour.
+
+### 4. Sanity checks
 Check the following
 
 1. The PHPCS file exists in your project root and points to the correct ruleset
@@ -59,7 +90,7 @@ configuration in youwe/testing-suite
 3. Run `ddev exec grumphp run` or `vendor/bin/grumphp run`
 4. Your git commit hook still functions as expected
 
-### 4. Refactor and/or update/regenerate exclusion rules
+### 5. Refactor and/or update/regenerate exclusion rules
 Some rulesets will have changed. In a general sense, the rulesets are less
 strict compared to what they were before.
 

--- a/config/default/grumphp.yml
+++ b/config/default/grumphp.yml
@@ -49,6 +49,7 @@ parameters:
   phpstan.configuration: ./phpstan.neon
   phpstan.level: 4
   phpstan.triggered_by: [php]
+  phpstan.use_grumphp_paths: false # Always (also during commit hook), scan the full project as described in https://phpstan.org/blog/why-you-should-always-analyse-whole-project
 
   phpunit.config_file: ./phpunit.xml
 
@@ -147,6 +148,7 @@ grumphp:
       configuration: '%phpstan.configuration%'
       level: '%phpstan.level%'
       triggered_by: '%phpstan.triggered_by%'
+      use_grumphp_paths: '%phpstan.use_grumphp_paths%'
 
     phpunit:
       config_file: '%phpunit.config_file%'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,3 @@
 parameters:
-  excludePaths:
-    - config/pimcore/phpstan-bootstrap.php
-    - src/installers.php
-    - tests/*
-  ignoreErrors:
-    - '#Property Mediact\\TestingSuite\\Composer\\Installer\\ConfigInstaller::\$io is never read, only written\.#'
+  paths:
+    - src

--- a/templates/files/default/phpstan.neon
+++ b/templates/files/default/phpstan.neon
@@ -1,3 +1,16 @@
+includes:
+  # To create a baseline run the following command and then uncomment the include below (make sure to run the baseline
+  # command with the same level as configured in Grumphp)
+  #      vendor/bin/phpstan analyse --configuration=./phpstan.neon --generate-baseline --level=4
+  # - phpstan-baseline.neon
+
 parameters:
+  paths:
+    # Configure the project folders containing source files, e.g.
+    - src
+
+    # Uncomment when your project has unit tests:
+    # - tests
+
   excludePaths:
-#    - %rootDir%/../../../path/to/exclude/*
+    # - tests/fixtures/*

--- a/templates/files/drupal/phpstan.neon
+++ b/templates/files/drupal/phpstan.neon
@@ -1,3 +1,16 @@
+includes:
+  # To create a baseline run the following command and then uncomment the include below (make sure to run the baseline
+  # command with the same level as configured in Grumphp)
+  #      vendor/bin/phpstan analyse --configuration=./phpstan.neon --generate-baseline --level=4
+  # - phpstan-baseline.neon
+
 parameters:
-  excludes_analyse:
-#    - %rootDir%/../../../path/to/exclude/*
+  paths:
+    - web
+
+    # Add any other project folder containing source files, e.g.
+    # - tests
+
+  excludePaths:
+    # Add any path you want to exclude (note, only files/folders within the configured `paths` are relevant to note here), e.g.:
+    # - tests/fixtures/*

--- a/templates/files/magento2/phpstan.neon
+++ b/templates/files/magento2/phpstan.neon
@@ -1,6 +1,15 @@
+includes:
+  # To create a baseline run the following command and then uncomment the include below (make sure to run the baseline
+  # command with the same level as configured in Grumphp)
+  #      vendor/bin/phpstan analyse --configuration=./phpstan.neon --generate-baseline --level=4
+  # - phpstan-baseline.neon
+
 parameters:
+  paths:
+    - app
+
+    # Add any other project folder containing source files, e.g.
+    # - bundles
+
   excludePaths:
-#    - %rootDir%/../../../path/to/exclude/*
-  ignoreErrors:
-    - '#(class|type) [A-z]*\\TestFramework#i'
-    - '#(class|type) [A-z]*\\\S*Factory#i'
+    - app/bootstrap.php # Ignore bootstrap.php provided by Magento2

--- a/templates/files/pimcore/phpstan.neon
+++ b/templates/files/pimcore/phpstan.neon
@@ -1,22 +1,24 @@
 includes:
   - vendor/phpstan/phpstan-symfony/extension.neon
 
-parameters:
-  excludePaths:
-    # Symfony files
-    - %rootDir%/../../../bin/console
-    - %rootDir%/../../../public/index.php
-    # Full var folder, contains all kind of auto-generated files (e.g. cache, generated Pimcore DataObject classes)
-    - %rootDir%/../../../var/*
-    # Configuration written by Pimcore (which is written either to var/ or to config/pimcore/ depending on settings)
-    - %rootDir%/../../../config/pimcore/*
-    # Unit tests
-    - %rootDir%/../../../tests/fixtures/*
-    # Deployer (which would be nice if it is correct too, but does need its own composer install, therefore excluding)
-    - %rootDir%/../../../build/deployer/*
+  # To create a baseline run the following command and then uncomment the include below (make sure to run the baseline
+  # command with the same level as configured in Grumphp)
+  #      vendor/bin/phpstan analyse --configuration=./phpstan.neon --generate-baseline --level=6
+  # - phpstan-baseline.neon
 
-    # Custom excludes
-    # - %rootDir%/../../../path/to/exclude/*
+parameters:
+  paths:
+    - src
+    - var/classes/DataObject # Include DataObject generated classes, otherwise PHPStan will complain about class not found
+
+    # Uncomment when your project has unit tests:
+    # - tests
+
+    # Add any other project folder containing source files, e.g.
+    # - bundles
+
+  excludePaths:
+    # - tests/fixtures/*
 
   # Point PHPStan to internal constants that are bootstrapped
   bootstrapFiles:


### PR DESCRIPTION
Error: PHPStan exited with "[ERROR] No files found to analyse." during the commit hook when only committing files in the excluded section
Caused by: PHPStan really wants to scan the whole project, which makes sense because a change in one file can break another file (which was not part of your commit)
Resolved with: Setting `use_grumphp_paths` option to false, include `paths` in `phpstan.neon`

Resolves #51

---

# Collaboration request

@eescribanoc Can we collaborate on the `phpstan.neon` template file for Drupal? See below
@leonhelmus  @rutgerrademaker  @igorwulff  Can we collaborate on the `phpstan.neon` template for Magento? See below

This is changing how PHPStan analyses your project. That also needs a reconfiguration of the `phpstan.neon` file. Basically it needs a `paths` config indicating which folders it needs to analyse. Typically that's `src` and `tests` but I don't want to make assumptions here.

As examples see `templates/files/pimcore/phpstan.neon` and the example I've written in the `MIGRATION.md`.

If you totally disagree with this change also let me know, but since PHPStan explicitly indicates this is the way to go (see https://phpstan.org/blog/why-you-should-always-analyse-whole-project ) I think this should be the default for all projects and not only Pimcore. Also apparently it's running into errors with the old setup (don't know though if that is a PHPStan version thing that Magento projects didn't run into yet or not) if you're committing only files that are excluded (which will happen with Pimcore project quite often as dataobject definition files are stored as .php).

Note that this is a change to a major version (bug is discovered in release candidate for 3.0.0) so we're free to make breaking changes at the moment.