### PR TITLE
config: disallow symfony dump function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   when the package was not installed (yet/anymore).
 - Default Pimcore coding standards disables PHPCS in favour of PHP CS Fixer.
 - JSON Lint will ignore folders `.ddev/` and `tests/fixtures/`.
+- Added Symfony function `dump()` to the git blacklist for all project types
 
 ### Removed
 - Removed support for EOL PHP versions. Projects running PHP < 8.1 can stick to version 2 of the testing-suite.

--- a/config/default/grumphp.yml
+++ b/config/default/grumphp.yml
@@ -59,6 +59,7 @@ parameters:
   git_blacklist.keywords:
     - "die("
     - "dd("
+    - "dump("
     - "var_dump("
     - "console.log("
     - "print_r("

--- a/config/magento2/grumphp.yml
+++ b/config/magento2/grumphp.yml
@@ -6,6 +6,7 @@ parameters:
   git_blacklist.keywords:
     - "die("
     - "dd("
+    - "dump("
     - "var_dump("
     - "console.log("
     - "print_r("

--- a/docs/components/git-blacklist.md
+++ b/docs/components/git-blacklist.md
@@ -16,6 +16,7 @@ several keywords in your commits.
 ```yaml
 - "die("
 - "dd("
+- "dump("
 - "var_dump("
 - "console.log("
 - "alert("


### PR DESCRIPTION
Disallow dump() calls (defined in the Symfony VarDumper)

Background:
- `dd()` was already blocked (which is Symfony's dump & die)
- PHP Native `var_dump()` was already blocked
- But Symfony's `dump()` was not blocked yet

Note: merging to version 3.0.0, although I don't really see this as a breaking change, even if you see it that way we're allowed right now