### PR TITLE
fix: exclude files from installed Symfony Bundles in PhpCsFixer

### DIFF
--- a/config/pimcore/php-cs-fixer/excludes.php
+++ b/config/pimcore/php-cs-fixer/excludes.php
@@ -6,6 +6,7 @@ return [
     // Symfony files
     'bin/console',
     'public/index.php',
+    'public/bundles',
     // Full var folder, contains all kind of auto-generated files (e.g. cache, generated Pimcore DataObject classes)
     'var',
     // Configuration written by Pimcore (which is written either to var/ or to config/pimcore/ depending on settings)


### PR DESCRIPTION
Error: PhpCsFixer complained about files in the public/bundles folder, but those are symlinks to Symfony bundles in the vendor/ folder
Resolved with: adding public/bundles to the exclude list

--

### Note:
Skipping the CHANGELOG on purpose. This is a bug that we discovered in the release candidate for 3.0.0 and the [CHANGELOG](https://github.com/YouweGit/testing-suite/blob/master/CHANGELOG.md) already has a `- Option to use PHP CS Fixer instead of PHPCS.` message