### PR TITLE
fix: don't rewrite composer.json empty objects to arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped support for Laravel and Magento 1.
 - Dropped inner dependencies on coding-standard, coding-standard-magento2, and coding-standard-phpstorm packages.
 
+### Fixed
+- The Composer Config Installer changed empty objects (e.g. a `"autoload-dev": {"psr-4": {}}`) into an empty array
+  (for previous example: `"autoload-dev": {"psr-4": []}`) causing an invalid `composer.json` file (followed by other
+  composer operations not being able to be performed). This is now fixed.
+
 ## 2.19.1
 ### Changed
 - `^0.30` restricts updates to only versions within the `0.30.x` range, preventing upgrades to 0.32.0 for

--- a/src/ComposerJsonWriter.php
+++ b/src/ComposerJsonWriter.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Youwe\TestingSuite\Composer;
+
+use Composer\Factory;
+use UnexpectedValueException;
+
+class ComposerJsonWriter
+{
+    private readonly string $file;
+
+    public function __construct(?string $file = null)
+    {
+        $this->file = $file ?? Factory::getComposerFile();
+    }
+
+    public function getContents(): object
+    {
+        return json_decode(file_get_contents($this->file), associative: false, flags: JSON_THROW_ON_ERROR);
+    }
+
+    public function setContents(object $contents): void
+    {
+        file_put_contents(
+            $this->file,
+            json_encode($contents, flags: JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+        );
+    }
+
+    public function mergeContents(object|array $settings, bool $overwrite = false): void
+    {
+        $this->setContents(
+            $this->mergeObject($this->getContents(), $settings, $overwrite),
+        );
+    }
+
+    private function mergeObject(?object $existing, object|array $new, bool $overwrite): object
+    {
+        if ($existing === null) {
+            $existing = (object) [];
+        }
+
+        foreach ((array) $new as $key => $value) {
+            if (is_array($value) && array_is_list($value)) {
+                // Merge lists
+                $existing->{$key} = $this->mergeList($existing->{$key} ?? [], $value);
+                continue;
+            }
+
+            if (is_object($value) || is_array($value)) {
+                // Deep merge new config
+                $existing->{$key} = $this->mergeObject($existing->{$key} ?? null, $value, $overwrite);
+                continue;
+            }
+
+            if (!$overwrite && isset($existing->{$key})) {
+                continue;
+            }
+
+            $existing->{$key} = $value;
+        }
+
+        return $existing;
+    }
+
+    private function mergeList(mixed $existing, array $new): array
+    {
+        if ($existing !== null && !is_array($existing)) {
+            throw new UnexpectedValueException('Can\'t merge an array list with ' . get_debug_type($existing));
+        }
+
+        return array_merge($existing ?? [], $new);
+    }
+}

--- a/src/Installer/ConfigInstaller.php
+++ b/src/Installer/ConfigInstaller.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 namespace Youwe\TestingSuite\Composer\Installer;
 
-use Composer\Factory;
-use Composer\Json\JsonFile;
-use Seld\JsonLint\ParsingException;
+use Youwe\TestingSuite\Composer\ComposerJsonWriter;
 use Youwe\TestingSuite\Composer\ConfigResolver;
 
 /**
@@ -20,43 +18,28 @@ use Youwe\TestingSuite\Composer\ConfigResolver;
  */
 class ConfigInstaller implements InstallerInterface
 {
-    /** @var JsonFile */
-    private $file;
-
-    /** @var ConfigResolver */
-    private $resolver;
-
     /**
      * Constructor.
      *
      * @param ConfigResolver $resolver
-     * @param JsonFile|null  $file
+     * @param ComposerJsonWriter $composerJsonWriter
      */
     public function __construct(
-        ConfigResolver $resolver,
-        ?JsonFile $file = null,
+        private readonly ConfigResolver $resolver,
+        private readonly ComposerJsonWriter $composerJsonWriter,
     ) {
-        $this->resolver = $resolver;
-        $this->file     = $file ?? new JsonFile(Factory::getComposerFile());
     }
 
     /**
      * Install.
      *
      * @return void
-     * @throws ParsingException
      */
     public function install(): void
     {
-        $definition = $this->file->read();
-        $config     = $definition['config'] ?? [];
-
-        $config = array_replace_recursive(
-            $this->resolver->resolve(),
-            $config,
+        $this->composerJsonWriter->mergeContents(
+            settings: ['config' => $this->resolver->resolve()],
+            overwrite: false,
         );
-
-        $definition['config'] = $config;
-        $this->file->write($definition);
     }
 }

--- a/src/installers.php
+++ b/src/installers.php
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 
+use Youwe\TestingSuite\Composer\ComposerJsonWriter;
 use Youwe\TestingSuite\Composer\ConfigResolver;
 use Youwe\TestingSuite\Composer\Installer\ArchiveExcludeInstaller;
 use Youwe\TestingSuite\Composer\Installer\ConfigInstaller;
@@ -23,10 +24,11 @@ use Youwe\TestingSuite\Composer\ProjectTypeResolver;
 $typeResolver    = new ProjectTypeResolver($composer);
 $mappingResolver = new MappingResolver($typeResolver);
 $configResolver  = new ConfigResolver($typeResolver);
+$composerJsonWriter = new ComposerJsonWriter();
 
 return [
     new FilesInstaller($mappingResolver, $io),
-    new ArchiveExcludeInstaller($mappingResolver, $io),
+    new ArchiveExcludeInstaller($mappingResolver, $io, $composerJsonWriter),
     new PackagesInstaller($composer, $typeResolver, $io),
-    new ConfigInstaller($configResolver),
+    new ConfigInstaller($configResolver, $composerJsonWriter),
 ];

--- a/tests/ComposerJsonWriterTest.php
+++ b/tests/ComposerJsonWriterTest.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Youwe\TestingSuite\Composer\Tests;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Youwe\TestingSuite\Composer\ComposerJsonWriter;
+
+#[CoversMethod(ComposerJsonWriter::class, '__construct')]
+#[CoversMethod(ComposerJsonWriter::class, 'getContents')]
+#[CoversMethod(ComposerJsonWriter::class, 'setContents')]
+#[CoversMethod(ComposerJsonWriter::class, 'mergeContents')]
+class ComposerJsonWriterTest extends TestCase
+{
+    private function getFilesystem(string $composerJson = '{}'): string
+    {
+        static $callNr = 0;
+
+        $filesystem = vfsStream::setup(
+            sha1(__METHOD__ . ($callNr++)),
+            null,
+            ['composer.json' => $composerJson],
+        );
+
+        return $filesystem->url() . '/composer.json';
+    }
+
+    public function testGetContents(): void
+    {
+        $file = $this->getFilesystem(
+            <<<'EOF'
+                {
+                    "name": "youwe/testing-suite",
+                    "empty-object": {},
+                    "empty-array": [],
+                    "nested-object": {"foo": "bar"},
+                    "nested-array": [42]
+                }
+                EOF,
+        );
+
+        $composerJsonWriter = new ComposerJsonWriter($file);
+
+        $this->assertEquals(
+            (object) [
+                'name' => 'youwe/testing-suite',
+                'empty-object' => (object) [],
+                'empty-array' => [],
+                'nested-object' => (object) ['foo' => 'bar'],
+                'nested-array' => [42],
+            ],
+            $composerJsonWriter->getContents(),
+        );
+    }
+
+    public function testSetContents(): void
+    {
+        $file = $this->getFilesystem();
+
+        $composerJsonWriter = new ComposerJsonWriter($file);
+        $composerJsonWriter->setContents(
+            (object) [
+                'name' => 'youwe/testing-suite',
+                'empty-object' => (object) [],
+                'empty-array' => [],
+                'nested-object' => (object) ['foo' => 'bar'],
+                'nested-array' => [42],
+            ],
+        );
+
+        $this->assertEquals(
+            <<<'EOF'
+                {
+                    "name": "youwe/testing-suite",
+                    "empty-object": {},
+                    "empty-array": [],
+                    "nested-object": {
+                        "foo": "bar"
+                    },
+                    "nested-array": [
+                        42
+                    ]
+                }
+                EOF,
+            file_get_contents($file),
+        );
+    }
+
+    #[DataProvider('mergeContentsDataProvider')]
+    public function testMergeContents(string $existing, array|object $settings, bool $overwrite, string $expected): void
+    {
+        $file = $this->getFilesystem($existing);
+
+        $composerJsonWriter = new ComposerJsonWriter($file);
+        $composerJsonWriter->mergeContents($settings, $overwrite);
+
+        $this->assertEquals(
+            $expected,
+            file_get_contents($file),
+        );
+    }
+
+    /**
+     * @return array<string, array{
+     *     existing: string,
+     *     settinsg: array|object,
+     *     overwrite: bool,
+     *     expected: string,
+     * }>
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
+    public static function mergeContentsDataProvider(): array
+    {
+        return [
+            'It appends settings when passed as object (overwrite true)' => [
+                'existing' => <<<EOF
+                                  {
+                                      "name": "youwe/testing-suite",
+                                      "config": {
+                                          "hello": "world"
+                                      }
+                                  }
+                                  EOF,
+                'settings' => (object) ['config' => (object) ['foo' => 'bar']],
+                'overwrite' => true,
+                'expected' => <<<EOF
+                                  {
+                                      "name": "youwe/testing-suite",
+                                      "config": {
+                                          "hello": "world",
+                                          "foo": "bar"
+                                      }
+                                  }
+                                  EOF,
+            ],
+            'It appends settings when passed as object (overwrite false)' => [
+                'existing' => <<<EOF
+                                  {
+                                      "name": "youwe/testing-suite",
+                                      "config": {
+                                          "hello": "world"
+                                      }
+                                  }
+                                  EOF,
+                'settings' => (object) ['config' => (object) ['foo' => 'bar']],
+                'overwrite' => false,
+                'expected' => <<<EOF
+                                  {
+                                      "name": "youwe/testing-suite",
+                                      "config": {
+                                          "hello": "world",
+                                          "foo": "bar"
+                                      }
+                                  }
+                                  EOF,
+            ],
+            'It appends settings when passed as associative array (overwrite true)' => [
+                'existing' => <<<EOF
+                                  {
+                                      "name": "youwe/testing-suite",
+                                      "config": {
+                                          "hello": "world"
+                                      }
+                                  }
+                                  EOF,
+                'settings' => ['config' => ['foo' => 'bar']],
+                'overwrite' => true,
+                'expected' => <<<EOF
+                                  {
+                                      "name": "youwe/testing-suite",
+                                      "config": {
+                                          "hello": "world",
+                                          "foo": "bar"
+                                      }
+                                  }
+                                  EOF,
+            ],
+            'It appends settings when passed as associative array (overwrite false)' => [
+                'existing' => <<<EOF
+                                  {
+                                      "name": "youwe/testing-suite",
+                                      "config": {
+                                          "hello": "world"
+                                      }
+                                  }
+                                  EOF,
+                'settings' => ['config' => ['foo' => 'bar']],
+                'overwrite' => false,
+                'expected' => <<<EOF
+                                  {
+                                      "name": "youwe/testing-suite",
+                                      "config": {
+                                          "hello": "world",
+                                          "foo": "bar"
+                                      }
+                                  }
+                                  EOF,
+            ],
+            'It overwrites settings when told so' => [
+                'existing' => <<<EOF
+                                  {
+                                      "name": "youwe/testing-suite",
+                                      "config": {
+                                          "hello": "world"
+                                      }
+                                  }
+                                  EOF,
+                'settings' => ['config' => ['hello' => 'Youwe', 'foo' => 'bar']],
+                'overwrite' => true,
+                'expected' => <<<EOF
+                                  {
+                                      "name": "youwe/testing-suite",
+                                      "config": {
+                                          "hello": "Youwe",
+                                          "foo": "bar"
+                                      }
+                                  }
+                                  EOF,
+            ],
+            'It keeps settings when not overwriting' => [
+                'existing' => <<<EOF
+                                  {
+                                      "name": "youwe/testing-suite",
+                                      "config": {
+                                          "hello": "world"
+                                      }
+                                  }
+                                  EOF,
+                'settings' => ['config' => ['hello' => 'Youwe', 'foo' => 'bar']],
+                'overwrite' => false,
+                'expected' => <<<EOF
+                                  {
+                                      "name": "youwe/testing-suite",
+                                      "config": {
+                                          "hello": "world",
+                                          "foo": "bar"
+                                      }
+                                  }
+                                  EOF,
+            ],
+            'It merges arrays' => [
+                'existing' => <<<EOF
+                                  {
+                                      "name": "youwe/testing-suite",
+                                      "repositories": [
+                                          {
+                                              "type": "composer",
+                                              "url": "https://packagist.org/"
+                                          }
+                                      ]
+                                  }
+                                  EOF,
+                'settings' => [
+                    'repositories' => [
+                        ['type' => 'vcs', 'url' => 'https://github.com/YouweGit/testing-suite.git'],
+                    ],
+                ],
+                'overwrite' => false,
+                'expected' => <<<EOF
+                    {
+                        "name": "youwe/testing-suite",
+                        "repositories": [
+                            {
+                                "type": "composer",
+                                "url": "https://packagist.org/"
+                            },
+                            {
+                                "type": "vcs",
+                                "url": "https://github.com/YouweGit/testing-suite.git"
+                            }
+                        ]
+                    }
+                    EOF,
+            ],
+        ];
+    }
+}

--- a/tests/Installer/ConfigInstallerTest.php
+++ b/tests/Installer/ConfigInstallerTest.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 
 namespace Youwe\TestingSuite\Composer\Tests\Installer;
 
-use Composer\Json\JsonFile;
 use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
+use Youwe\TestingSuite\Composer\ComposerJsonWriter;
 use Youwe\TestingSuite\Composer\ConfigResolver;
 use Youwe\TestingSuite\Composer\Installer\ConfigInstaller;
 
@@ -29,9 +29,9 @@ class ConfigInstallerTest extends TestCase
     public function testInstall(): void
     {
         $resolver = $this->createMock(ConfigResolver::class);
-        $file     = $this->createMock(JsonFile::class);
+        $composerJsonWriter = $this->createMock(ComposerJsonWriter::class);
 
-        $installer = new ConfigInstaller($resolver, $file);
+        $installer = new ConfigInstaller($resolver, $composerJsonWriter);
 
         $resolverOutput = [
             'sort-packages' => true,
@@ -41,20 +41,15 @@ class ConfigInstallerTest extends TestCase
             'config' => $resolverOutput,
         ];
 
-        $file
+        $composerJsonWriter
             ->expects(self::once())
-            ->method('read')
-            ->willReturn([]);
+            ->method('mergeContents')
+            ->with($configWrite, false);
 
         $resolver
             ->expects(self::once())
             ->method('resolve')
             ->willReturn($resolverOutput);
-
-        $file
-            ->expects(self::once())
-            ->method('write')
-            ->with($configWrite);
 
         $installer->install();
     }
@@ -68,7 +63,7 @@ class ConfigInstallerTest extends TestCase
             [
                 [],
                 [
-                    'sort-packages' => true
+                    'sort-packages' => true,
                 ],
             ],
             [
@@ -76,7 +71,7 @@ class ConfigInstallerTest extends TestCase
                 [
                     'extra' => [
                         'grumphp' => [
-                            'config-default-path' => 'vendor/youwe/testing-suite/config/default/grumphp.yml'
+                            'config-default-path' => 'vendor/youwe/testing-suite/config/default/grumphp.yml',
                         ],
                     ],
                 ],


### PR DESCRIPTION
Error: the installers writing changes to composer.json converted empty objects to empty arrays
Caused by: using json_decode with associative true Resolved with: use json_decode with associative false so that types remain the same