### PR TITLE
fix: use PHPStan version >=2 for Pimcore projects

### DIFF
--- a/src/Installer/PackagesInstaller.php
+++ b/src/Installer/PackagesInstaller.php
@@ -56,6 +56,10 @@ class PackagesInstaller implements InstallerInterface
             ]
         ],
         'pimcore' => [
+            'phpstan/phpstan' => [
+                'version' => '>=2.0',
+                'updateDependencies' => true,
+            ],
             'phpstan/phpstan-symfony' => [
                 'version' => '@stable',
                 'updateDependencies' => true,

--- a/templates/files/pimcore/phpstan.neon
+++ b/templates/files/pimcore/phpstan.neon
@@ -9,7 +9,6 @@ includes:
 parameters:
   paths:
     - src
-    - var/classes/DataObject # Include DataObject generated classes, otherwise PHPStan will complain about class not found
 
     # Uncomment when your project has unit tests:
     # - tests
@@ -23,3 +22,9 @@ parameters:
   # Point PHPStan to internal constants that are bootstrapped
   bootstrapFiles:
     - ./vendor/youwe/testing-suite/config/pimcore/phpstan-bootstrap.php
+
+  ignoreErrors:
+    # PHPStan won't correctly recognize "@var Pimcore\Model\DataObject\ClassName $this", something we often use in
+    # abstract models. The "varTag.nativeType" rule has been added recently to PHPStan and apparently is not stable
+    # enough yet. Disable this check completely.
+    - { identifier: varTag.nativeType }


### PR DESCRIPTION
Bumping to version >=2 (for Pimcore only) and making PHPStan 2 related
adjustments in phpstan.neon because PHPStan 1 vs 2 requires a slightly
different configuration, and we prefer a default config that always
works.