### PR TITLE
fix: PHPMD does not require schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.4]
+### Fixed
+- Error: Failed to locate the main schema resource at 'https://pmd.sourceforge.io/ruleset_xml_schema.xsd'.
+### Removed
+- Schema validation for PHPMD.
+
 ## [3.0.3]
 ### Fixed
 - When running GrumPHP on an environment with the Redis PHP extension installed, it errored with `The package 

--- a/config/default/phpmd.xml
+++ b/config/default/phpmd.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="Youwe/Global"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+<ruleset name="Youwe/Global" xmlns="http://pmd.sf.net/ruleset/1.0.0">
     <description>Default / Fallback configuration for PHPMD rulesets.</description>
 
     <!-- Taken from Global ruleset since we can't modify a referenced rule without overwriting it completely.

--- a/config/drupal/phpmd.xml
+++ b/config/drupal/phpmd.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="PHPMD"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+<ruleset name="PHPMD" xmlns="http://pmd.sf.net/ruleset/1.0.0">
     <description>PHPMD rules for Drupal projects.</description>
     <rule ref="./config/default/phpmd.xml" />
 

--- a/config/magento2/phpmd.xml
+++ b/config/magento2/phpmd.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="PHPMD"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+<ruleset name="PHPMD" xmlns="http://pmd.sf.net/ruleset/1.0.0">
     <description>PHPMD rules for Magento 2 projects.</description>
 
     <!-- Taken from Global ruleset since we can't modify a referenced rule without overwriting it completely.

--- a/config/pimcore/phpmd.xml
+++ b/config/pimcore/phpmd.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="PHPMD"
-         xmlns="https://pmd.sf.net/ruleset/1.0.0"
-         xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+<ruleset name="PHPMD" xmlns="https://pmd.sf.net/ruleset/1.0.0">
     <description>PHPMD rules for Pimcore projects.</description>
 
     <!-- Taken from Global ruleset since we can't modify a referenced rule without overwriting it completely.

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="PHPMD"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+<ruleset name="PHPMD" xmlns="http://pmd.sf.net/ruleset/1.0.0">
     <description>PHPMD</description>
     <rule ref="./config/default/phpmd.xml">
         <exclude name="ShortVariable"/>

--- a/templates/files/default/phpmd.xml
+++ b/templates/files/default/phpmd.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="PHPMD"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+<ruleset name="PHPMD" xmlns="http://pmd.sf.net/ruleset/1.0.0">
     <description>PHPMD</description>
     <!--<exclude-pattern>path/to/exclude/*</exclude-pattern>-->
     <rule ref="./vendor/youwe/testing-suite/config/default/phpmd.xml" />

--- a/templates/files/drupal/phpmd.xml
+++ b/templates/files/drupal/phpmd.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="PHPMD"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+<ruleset name="PHPMD" xmlns="http://pmd.sf.net/ruleset/1.0.0">
     <description>PHPMD</description>
     <!--<exclude-pattern>path/to/exclude/*</exclude-pattern>-->
     <rule ref="./vendor/youwe/testing-suite/config/drupal/phpmd.xml" />

--- a/templates/files/magento2/phpmd.xml
+++ b/templates/files/magento2/phpmd.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="PHPMD"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+<ruleset name="PHPMD" xmlns="http://pmd.sf.net/ruleset/1.0.0">
     <description>PHPMD</description>
     <!--<exclude-pattern>path/to/exclude/*</exclude-pattern>-->
     <rule ref="./vendor/youwe/testing-suite/config/magento2/phpmd.xml" />

--- a/templates/files/pimcore/phpmd.xml
+++ b/templates/files/pimcore/phpmd.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="PHPMD"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+<ruleset name="PHPMD" xmlns="http://pmd.sf.net/ruleset/1.0.0">
     <description>PHPMD</description>
     <!--<exclude-pattern>path/to/exclude/*</exclude-pattern>-->
     <rule ref="./vendor/youwe/testing-suite/config/pimcore/phpmd.xml" />


### PR DESCRIPTION
The simplest fix is to remove the schema declaration.