### PR TITLE
Fix incorrect override of CouplingBetweenObjects for Magento 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Magento 2 `phpmd.xml` incorrectly overrode `CouplingBetweenObjects`: the design ruleset was included twice, causing
+  the check to run with conflicting maximum values. The original rule is now excluded so the custom override (20)
+  takes effect.
+
 ## [3.1.0]
 ### Added
 - Option `security_checker.blocking` which defaults to `true`, but can be configured as `false` within libraries and 

--- a/config/magento2/phpmd.xml
+++ b/config/magento2/phpmd.xml
@@ -18,7 +18,9 @@
         <exclude name="BooleanArgumentFlag"/>
     </rule>
 
-    <rule ref="rulesets/design.xml" />
+    <rule ref="rulesets/design.xml">
+        <exclude name="CouplingBetweenObjects"/>
+    </rule>
     <rule ref="rulesets/unusedcode.xml">
         <!-- In Magento unused parameters are common, for example in plugins, $subject is required, but often not used. -->
         <exclude name="UnusedFormalParameter" />

--- a/config/magento2/phpmd.xml
+++ b/config/magento2/phpmd.xml
@@ -19,6 +19,7 @@
     </rule>
 
     <rule ref="rulesets/design.xml">
+        <!-- For this rule we have exceptions configured below -->
         <exclude name="CouplingBetweenObjects"/>
     </rule>
     <rule ref="rulesets/unusedcode.xml">


### PR DESCRIPTION
It's not possible to override PHPMD config, so the design ruleset with its default CouplingBetweenObjects set to 13 and the custom override below of 20 resulted in the check being done twice with two different maximum values.

By excluding the original value the override from 13 to 20 does work as expected.