### PR TITLE
feat: allow non-blocking security tests on libraries/bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0]
+### Added
+- Option `security_checker.blocking` which defaults to `true`, but can be configured as `false` within libraries and 
+  bundles. Setting to `false` will still warn about security issues, but will not block the commit or merge. This 
+  setting should not be overridden in applications and projects.
+
 ## [3.0.5]
 ### Changed
 - Magento phpmd.xml loosened some rules to be more inline with what is 'normal' in Magento.

--- a/config/default/grumphp.yml
+++ b/config/default/grumphp.yml
@@ -58,6 +58,12 @@ parameters:
 
   securitychecker.lockfile: ./composer.lock
   securitychecker.run_always: true
+  securitychecker.blocking: true # This value should be true for all applications/projects and is only allowed to be
+                                 # overridden in libraries/bundles. Set to false if you want to allow commits even when
+                                 # vulnerabilities are found. This is useful for libraries and bundles, where the
+                                 # composer.lock file is excluded from git and thus the developer has less control over
+                                 # which exact version is installed during automated tests. The system will still warn
+                                 # about vulnerabilities found.
   securitychecker.allow_list: []
 
   git_blacklist.keywords:
@@ -195,6 +201,8 @@ grumphp:
       config_file: '%phpunit.config_file%'
 
     securitychecker_enlightn:
+      metadata:
+        blocking: '%securitychecker.blocking%'
       lockfile: '%securitychecker.lockfile%'
       run_always: '%securitychecker.run_always%'
       allow_list: '%securitychecker.allow_list%'

--- a/templates/files/default/grumphp.yml
+++ b/templates/files/default/grumphp.yml
@@ -7,3 +7,9 @@ parameters:
 
   # Or to disable the requirement for a Jira ticket number in the commit message:
   # git_commit_message.jira_matcher: '/.*/'
+
+  # securitychecker.blocking: false # Only allowed to be set to false for libraries/bundles where the composer.lock is
+  #                                 # git excluded. This should remain enabled on all applications/projects.
+  # securitychecker.allow_list:
+  #  - CVE-2002-0121 # Add a jira ticket indicating when this vulnerability will be fixed (update/upgrade will be
+  #                  # performed). Within that ticket explain this (new) vulnerability.

--- a/templates/files/drupal/grumphp.yml
+++ b/templates/files/drupal/grumphp.yml
@@ -1,2 +1,15 @@
 imports:
   - resource: 'vendor/youwe/testing-suite/config/pimcore/grumphp.yml'
+
+parameters:
+  # Configure your Jira Project codes as pipe-separated value:
+  # git_commit_message.jira_projects: 'PIMBBBBABC|MAGBBBBDEF|P012345'
+
+  # Or to disable the requirement for a Jira ticket number in the commit message:
+  # git_commit_message.jira_matcher: '/.*/'
+
+  # securitychecker.blocking: false # Only allowed to be set to false for libraries/bundles where the composer.lock is
+  #                                 # git excluded. This should remain enabled on all applications/projects.
+  # securitychecker.allow_list:
+  #  - CVE-2002-0121 # Add a jira ticket indicating when this vulnerability will be fixed (update/upgrade will be
+  #                  # performed). Within that ticket explain this (new) vulnerability.

--- a/templates/files/magento2/grumphp.yml
+++ b/templates/files/magento2/grumphp.yml
@@ -7,3 +7,9 @@ parameters:
 
   # Or to disable the requirement for a Jira ticket number in the commit message:
   # git_commit_message.jira_matcher: '/.*/'
+
+  # securitychecker.blocking: false # Only allowed to be set to false for libraries/bundles where the composer.lock is
+  #                                 # git excluded. This should remain enabled on all applications/projects.
+  # securitychecker.allow_list:
+  #  - CVE-2002-0121 # Add a jira ticket indicating when this vulnerability will be fixed (update/upgrade will be
+  #                  # performed). Within that ticket explain this (new) vulnerability.

--- a/templates/files/pimcore/grumphp.yml
+++ b/templates/files/pimcore/grumphp.yml
@@ -2,18 +2,20 @@ imports:
   - resource: 'vendor/youwe/testing-suite/config/pimcore/grumphp.yml'
 
 parameters:
-#  phpstan.level: 6 # The default PHPStan level for Pimcore is 6, but you might want to lower it for your project
-                    # when you're working towards stricter rules (and then increment it with every refactoring).
-                    # See https://phpstan.org/user-guide/rule-levels for more explanation about the different levels.
-                    # - For Pimcore 10.4 till 10.x: suggest to use level 5 maximum
-                    # - For Pimcore 10.0 till 10.3.x: suggest to use level 4 maximum
+  # phpstan.level: 6 # The default PHPStan level for Pimcore is 6, but you might want to lower it for your project
+                     # when you're working towards stricter rules (and then increment it with every refactoring).
+                     # See https://phpstan.org/user-guide/rule-levels for more explanation about the different levels.
+                     # - For Pimcore 10.4 till 10.x: suggest to use level 5 maximum
+                     # - For Pimcore 10.0 till 10.3.x: suggest to use level 4 maximum
 
-#  Configure your Jira Project codes as pipe-separated value:
-#  git_commit_message.jira_projects: 'PIMBBBBABC|MAGBBBBDEF|P012345'
+  # Configure your Jira Project codes as pipe-separated value:
+  # git_commit_message.jira_projects: 'PIMBBBBABC|MAGBBBBDEF|P012345'
 
-#  Or to disable the requirement for a Jira ticket number in the commit message:
-#  git_commit_message.jira_matcher: '/.*/'
+  # Or to disable the requirement for a Jira ticket number in the commit message:
+  # git_commit_message.jira_matcher: '/.*/'
 
-#  securitychecker.allow_list:
-#    - CVE-2002-0121 # Add a jira ticket indicating when this vulnerability will be fixed (update/upgrade will be
-                     #    performed). Within that ticket explain this (new) vulnerability.
+  # securitychecker.blocking: false # Only allowed to be set to false for libraries/bundles where the composer.lock is
+  #                                 # git excluded. This should remain enabled on all applications/projects.
+  # securitychecker.allow_list:
+  #  - CVE-2002-0121 # Add a jira ticket indicating when this vulnerability will be fixed (update/upgrade will be
+  #                  # performed). Within that ticket explain this (new) vulnerability.


### PR DESCRIPTION
On libraries/bundles the composer.lock file is normally excluded from git, meaning we have less control over which versions of dependencies is installed in the build pipeline. This can cause issues especially if there are conflicting nested dependencies and Composer will make a decision which set of versions will be installed.

For that reason we'll allow to mark the security checker as non-blocking within libraries and bundles.

Within applications and projects the security checker should still remain enabled and blocking - as that's where the security findings actually matter.

Resolves P002952-35