### PR TITLE
fix: PHPMD version 3 backwards compatible issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.1.1]
 ### Fixed
 - Magento 2 `phpmd.xml` incorrectly overrode `CouplingBetweenObjects`: the design ruleset was included twice, causing
   the check to run with conflicting maximum values. The original rule is now excluded so the custom override (20)
   takes effect.
+- PHPMD 3.x-dev requires a different commandline argument notation than the 2.x version. GrumPHP does not support this
+  new notation (yet). This has been resolved by using a wrapper script to rewrite the argument notation if PHPMD 3 is
+  installed.
 
 ## [3.1.0]
 ### Added

--- a/command-wrappers/phpmd
+++ b/command-wrappers/phpmd
@@ -1,0 +1,39 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Grumphp calls PHPMD with the version 2.x set of arguments and doesn't have compatibility yet with the 3.x-dev
+ * argument notation. This script detects the PHPMD version and rewrites the arguments to match
+ */
+
+$pathToPhpmd = getcwd() . '/vendor/bin/phpmd';
+
+exec(escapeshellarg($pathToPhpmd) . ' --version', $versionOutput);
+
+if (stripos($versionOutput[0] ?? '', 'PHPMD 3') === 0) {
+    // PHPMD 3.x installed, rewrite arguments
+
+    array_shift($argv); // Shift command
+    $filesCommaSeparated = array_shift($argv);
+    $format = array_shift($argv);
+    $ruleset = array_shift($argv);
+
+    // Rewrite
+    // phpmd 'file1.php,file2.php' 'text' 'ruleset1.xml' --original-option-1 --original-option-2
+    // to
+    // $pathToPhpmd analyze --threads=1 --format=text --ruleset='ruleset1.xml'  --original-option-1 --original-option-2 -- file1.php file2.php
+    $argv = [
+        $pathToPhpmd,
+        'analyze',
+        '--threads=1', // Note: Multithreading doesn't work good (yet) and it doesn't report errors if we don't force it to single thread
+        '--format=' . $format,
+        '--ruleset=' . $ruleset,
+        ...$argv,
+        '--',
+        ...explode(',', $filesCommaSeparated),
+    ];
+
+    $_SERVER['argv'] = $argv;
+}
+
+include $pathToPhpmd;

--- a/config/default/grumphp.yml
+++ b/config/default/grumphp.yml
@@ -124,6 +124,10 @@ grumphp:
   parallel:
     enabled: true
 
+  environment:
+    paths:
+      - './vendor/youwe/testing-suite/command-wrappers'
+
   # Default tasks for testing suite
   tasks:
     composer:


### PR DESCRIPTION
PHPMD 3.x-dev requires a different commandline argument notation than the 2.x version. GrumPHP does not support this new notation (yet). This has been resolved by using a wrapper script to rewrite the argument
 notation if PHPMD 3 is installed.