### PR TITLE
chore: Update phpmd schema files to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.2]
+### Fixed
+- `Failed to locate the main schema resource at 'https://pmd.sourceforge.io/ruleset_xml_schema.xsd'` for php 8.3 and 8.4)
+
+### Changed
+- Update phpmd schema files to 2.0.0 (to match testing-suite's own requirements).
+
 ## [3.1.1]
 ### Fixed
 - Magento 2 `phpmd.xml` incorrectly overrode `CouplingBetweenObjects`: the design ruleset was included twice, causing

--- a/config/default/phpmd.xml
+++ b/config/default/phpmd.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
-<ruleset name="Youwe/Global"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+<ruleset name="PHPMD"
+         xmlns="http://pmd.github.io/schema/ruleset/2.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="http://pmd.github.io/schema/ruleset/2.0.0 https://pmd.github.io/schema/ruleset_2_0_0.xsd">
     <description>Default / Fallback configuration for PHPMD rulesets.</description>
 
     <!-- Taken from Global ruleset since we can't modify a referenced rule without overwriting it completely.

--- a/config/drupal/phpmd.xml
+++ b/config/drupal/phpmd.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <ruleset name="PHPMD"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="http://pmd.github.io/schema/ruleset/2.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="http://pmd.github.io/schema/ruleset/2.0.0 https://pmd.github.io/schema/ruleset_2_0_0.xsd">
     <description>PHPMD rules for Drupal projects.</description>
     <rule ref="./config/default/phpmd.xml" />
 

--- a/config/magento2/phpmd.xml
+++ b/config/magento2/phpmd.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <ruleset name="PHPMD"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="http://pmd.github.io/schema/ruleset/2.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="http://pmd.github.io/schema/ruleset/2.0.0 https://pmd.github.io/schema/ruleset_2_0_0.xsd">
     <description>PHPMD rules for Magento 2 projects.</description>
 
     <!-- Taken from Global ruleset since we can't modify a referenced rule without overwriting it completely.

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -4,11 +4,11 @@ imports:
 parameters:
   composer.strict: false
   xmllint.ignore_patterns:
-    - /^phpcs.xml$/
-    - /^phpmd.xml$/
-    - /^phpunit.xml$/
-    - /^pdepend.xml$/
-    - /^templates/
+    - /phpcs\.xml$/
+    - /phpmd\.xml$/
+    - /phpunit\.xml$/
+    - /pdepend\.xml$/
+    - /templates/
 
   # Disable requirement for Jira ticket number in the commit message
   git_commit_message.jira_matcher: '/.*/'

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0"?>
 <ruleset name="PHPMD"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="http://pmd.github.io/schema/ruleset/2.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="http://pmd.github.io/schema/ruleset/2.0.0 https://pmd.github.io/schema/ruleset_2_0_0.xsd">
     <description>PHPMD</description>
+
     <rule ref="./config/default/phpmd.xml">
         <exclude name="ShortVariable"/>
     </rule>

--- a/templates/files/default/phpmd.xml
+++ b/templates/files/default/phpmd.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <ruleset name="PHPMD"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="http://pmd.github.io/schema/ruleset/2.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="http://pmd.github.io/schema/ruleset/2.0.0 https://pmd.github.io/schema/ruleset_2_0_0.xsd">
     <description>PHPMD</description>
     <!--<exclude-pattern>path/to/exclude/*</exclude-pattern>-->
-    <rule ref="./vendor/youwe/testing-suite/config/default/phpmd.xml" />
+    <rule ref="./vendor/youwe/testing-suite/config/pimcore/phpmd.xml" />
 </ruleset>

--- a/templates/files/drupal/phpmd.xml
+++ b/templates/files/drupal/phpmd.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <ruleset name="PHPMD"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="http://pmd.github.io/schema/ruleset/2.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="http://pmd.github.io/schema/ruleset/2.0.0 https://pmd.github.io/schema/ruleset_2_0_0.xsd">
     <description>PHPMD</description>
     <!--<exclude-pattern>path/to/exclude/*</exclude-pattern>-->
     <rule ref="./vendor/youwe/testing-suite/config/drupal/phpmd.xml" />

--- a/templates/files/magento2/phpmd.xml
+++ b/templates/files/magento2/phpmd.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <ruleset name="PHPMD"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="http://pmd.github.io/schema/ruleset/2.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="http://pmd.github.io/schema/ruleset/2.0.0 https://pmd.github.io/schema/ruleset_2_0_0.xsd">
     <description>PHPMD</description>
     <!--<exclude-pattern>path/to/exclude/*</exclude-pattern>-->
     <rule ref="./vendor/youwe/testing-suite/config/magento2/phpmd.xml" />

--- a/templates/files/pimcore/phpmd.xml
+++ b/templates/files/pimcore/phpmd.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <ruleset name="PHPMD"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="http://pmd.github.io/schema/ruleset/2.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://pmd.sourceforge.io/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="http://pmd.github.io/schema/ruleset/2.0.0 https://pmd.github.io/schema/ruleset_2_0_0.xsd">
     <description>PHPMD</description>
     <!--<exclude-pattern>path/to/exclude/*</exclude-pattern>-->
     <rule ref="./vendor/youwe/testing-suite/config/pimcore/phpmd.xml" />


### PR DESCRIPTION
Previously, testing-suite would fail `xmllint` (on itself) with a `Failed to locate the main schema resource at
'https://pmd.sourceforge.io/ruleset_xml_schema.xsd'` errors.

This commit make sure to update to the correct references, while also making sure local references can be fetched (by altering the grummphp file's `xmllint.ignore.patterns`)